### PR TITLE
fix check_login error

### DIFF
--- a/libxduauth/sites/ehall.py
+++ b/libxduauth/sites/ehall.py
@@ -41,4 +41,7 @@ class EhallSession(IDSSession):
         return search_result[0]['appId']
 
     def is_logged_in(self):
-        return self.get('http://ehall.xidian.edu.cn/jsonp/userFavoriteApps.json').json()['hasLogin']
+        return self.get('http://ehall.xidian.edu.cn/jsonp/userFavoriteApps.json',
+                        headers={
+                            "Cookie": "route=7d88f93d9c668334ecfc2502d54b2b32; amp.locale=undefined"
+                        }).json()['hasLogin']


### PR DESCRIPTION
without headers will get <response 500> and raise JSONDecodeError.
![image](https://user-images.githubusercontent.com/75836227/218626236-781a8fbc-66db-4266-bebb-9e5b8eda1403.png)

adding the cookie in headers can fix this error
